### PR TITLE
Update ts config

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -2,6 +2,10 @@
   "$schema": "http://json.schemastore.org/package",
   "private": true,
   "name": "common",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "exports": {
     "./persist": "./persist.js",
     "./persist.js": "./persist.js"

--- a/common/persist.ts
+++ b/common/persist.ts
@@ -21,7 +21,10 @@ export function persist<I, T extends Hashable, Q extends Question.Metadata, S>(
       const dir = path.dirname(file);
 
       fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(file, format(input, rules, [...outcomes]) + "\n");
+      fs.writeFileSync(
+        file,
+        (await format(input, rules, [...outcomes])) + "\n"
+      );
 
       return `${message}, see the full report at ${file}`;
     });

--- a/common/persist.ts
+++ b/common/persist.ts
@@ -1,19 +1,19 @@
 /// <reference types="node" />
 
 import { Question } from "@siteimprove/alfa-act";
-import { Handler } from "@siteimprove/alfa-assert";
+import type { Handler } from "@siteimprove/alfa-assert";
 import { Formatter } from "@siteimprove/alfa-formatter";
 import earl from "@siteimprove/alfa-formatter-earl";
 import { Future } from "@siteimprove/alfa-future";
 import { Hashable } from "@siteimprove/alfa-hash";
-import { Mapper } from "@siteimprove/alfa-mapper";
+import type { Mapper } from "@siteimprove/alfa-mapper";
 
 import * as fs from "fs";
 import * as path from "path";
 
 export function persist<I, T extends Hashable, Q extends Question.Metadata, S>(
   output: Mapper<I, string>,
-  format: Formatter<I, T, Q, S> = earl()
+  format: Formatter<I, T, Q, S> = earl.default()
 ): Handler<I, T, Q, S> {
   return (input, rules, outcomes, message) =>
     Future.from(async () => {

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -32,7 +32,10 @@ const config: KnipConfig = {
     "unit-testing/*": { entry, project },
     "unit-testing/angular": { entry: ["components/*.ts", "setup.ts"], project },
     "unit-testing/react": { entry: ["components/*.tsx", "setup.ts"], project },
-    "unit-testing/vue": { entry: ["components/*.ts", "setup.ts"], project },
+    "unit-testing/vue": {
+      entry: ["components/*.ts", "jsdom-environment.ts", "setup.ts"],
+      project,
+    },
   },
 };
 

--- a/custom-testing/adding-rules/package.json
+++ b/custom-testing/adding-rules/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-act": "^0.81.0",
     "@siteimprove/alfa-chai": "^0.65.2",

--- a/custom-testing/adding-rules/test/page.spec.ts
+++ b/custom-testing/adding-rules/test/page.spec.ts
@@ -11,6 +11,8 @@ import { Future } from "@siteimprove/alfa-future";
 import { Playwright } from "@siteimprove/alfa-playwright";
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as playwright from "playwright";
 
 import * as alfa from "@siteimprove/alfa-chai";
@@ -60,7 +62,7 @@ const myRule = Rule.Atomic.of<Page, Element>({
 });
 
 // adding myRule to the default ruleset
-const allRules = rules.append(myRule);
+const allRules = rules.default.append(myRule);
 
 // Creating a Chai plugin which runs all rules (default and custom).
 chai.use(
@@ -73,6 +75,10 @@ chai.use(
 
 const { expect } = chai;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 describe("page.html", () => {
   let browser: playwright.Browser;
   let page: playwright.Page;
@@ -82,7 +88,9 @@ describe("page.html", () => {
     browser = await playwright.chromium.launch();
     page = await browser.newPage();
 
-    await page.goto(`file://${require.resolve("./fixtures/page.html")}`);
+    await page.goto(
+      url.pathToFileURL(path.join(__dirname, "fixtures", "page.html")).href
+    );
 
     document = await page.evaluateHandle(() => window.document);
   });

--- a/custom-testing/answering/package.json
+++ b/custom-testing/answering/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-act": "^0.81.0",
     "@siteimprove/alfa-chai": "^0.65.2",

--- a/custom-testing/answering/test/answering.spec.ts
+++ b/custom-testing/answering/test/answering.spec.ts
@@ -12,6 +12,8 @@ import { Refinement } from "@siteimprove/alfa-refinement";
 import rules, { Question } from "@siteimprove/alfa-rules";
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as playwright from "playwright";
 
 import * as alfa from "@siteimprove/alfa-chai";
@@ -24,7 +26,7 @@ const { and } = Refinement;
 chai.use(
   alfa.Chai.createPlugin(
     (value: Playwright.Type) => Future.from(Playwright.toPage(value)),
-    rules.filter((rule) => !rule.uri.includes("r111")),
+    rules.default.filter((rule) => !rule.uri.includes("r111")),
     [persist(() => "test/outcomes/page.spec.json")]
   )
 );
@@ -35,9 +37,13 @@ const { expect } = chai;
 let browser: playwright.Browser;
 let page: playwright.Page;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 async function load(file: string): Promise<playwright.JSHandle> {
-  const path = `./fixtures/${file}`;
-  await page.goto(`file://${require.resolve(path)}`);
+  const fixture = path.join(__dirname, "fixtures", file);
+  await page.goto(url.pathToFileURL(fixture).href);
 
   return page.evaluateHandle(() => window.document);
 }

--- a/custom-testing/crawling/crawling.ts
+++ b/custom-testing/crawling/crawling.ts
@@ -1,5 +1,6 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as url from "node:url";
+import * as path from "node:path";
 
 import { Audit, Outcome, Question } from "@siteimprove/alfa-act";
 import { Crawler } from "@siteimprove/alfa-crawler";
@@ -15,12 +16,16 @@ if (!scope) {
   process.exit(1);
 }
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const frontier = Frontier.of(scope, [scope, ...seed]);
 
 Crawler.with(async (crawler) => {
   for await (const result of crawler.crawl(frontier)) {
     for (const input of result) {
-      const outcomes = await Audit.of(input, rules)
+      const outcomes = await Audit.of(input, rules.default)
         .evaluate()
         .map((outcomes) => [...outcomes]);
 

--- a/custom-testing/crawling/package.json
+++ b/custom-testing/crawling/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "node crawling.js"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-act": "^0.81.0",
     "@siteimprove/alfa-crawler": "^0.65.2",

--- a/custom-testing/filtering/package.json
+++ b/custom-testing/filtering/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-act": "^0.81.0",
     "@siteimprove/alfa-chai": "^0.65.2",

--- a/custom-testing/filtering/test/filtering.spec.ts
+++ b/custom-testing/filtering/test/filtering.spec.ts
@@ -10,6 +10,8 @@ import { Refinement } from "@siteimprove/alfa-refinement";
 import { Conformance, Criterion, Technique } from "@siteimprove/alfa-wcag";
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as playwright from "playwright";
 
 import * as alfa from "@siteimprove/alfa-chai";
@@ -24,7 +26,7 @@ const { and } = Refinement;
 chai.use(
   alfa.Chai.createPlugin(
     (value: Playwright.Type) => Future.from(Playwright.toPage(value)),
-    rules.filter((rule) => !rule.uri.includes("r111")),
+    rules.default.filter((rule) => !rule.uri.includes("r111")),
     [persist(() => "test/outcomes/filtering.spec.json")]
   )
 );
@@ -35,9 +37,13 @@ const { expect } = chai;
 let browser: playwright.Browser;
 let page: playwright.Page;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 async function load(file: string): Promise<playwright.JSHandle> {
-  const path = `./fixtures/${file}`;
-  await page.goto(`file://${require.resolve(path)}`);
+  const fixture = path.join(__dirname, "fixtures", file);
+  await page.goto(url.pathToFileURL(fixture).href);
 
   return page.evaluateHandle(() => window.document);
 }

--- a/custom-testing/interacting/package.json
+++ b/custom-testing/interacting/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-chai": "^0.65.2",
     "@siteimprove/alfa-future": "^0.81.0",

--- a/custom-testing/interacting/test/interacting.spec.ts
+++ b/custom-testing/interacting/test/interacting.spec.ts
@@ -5,6 +5,8 @@ import { Future } from "@siteimprove/alfa-future";
 import { Playwright } from "@siteimprove/alfa-playwright";
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as playwright from "playwright";
 
 import * as alfa from "@siteimprove/alfa-chai";
@@ -25,6 +27,10 @@ chai.use(
 
 const { expect } = chai;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 describe("Interacting with a page", () => {
   let browser: playwright.Browser;
   let page: playwright.Page;
@@ -34,7 +40,9 @@ describe("Interacting with a page", () => {
     browser = await playwright.chromium.launch();
     page = await browser.newPage();
 
-    await page.goto(`file://${require.resolve("./fixtures/page.html")}`);
+    await page.goto(
+      url.pathToFileURL(path.join(__dirname, "fixtures", "page.html")).href
+    );
 
     document = await page.evaluateHandle(() => window.document);
   });

--- a/custom-testing/measuring-performances/package.json
+++ b/custom-testing/measuring-performances/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "node performance.js"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-act": "^0.81.0",
     "@siteimprove/alfa-aria": "^0.81.0",

--- a/custom-testing/measuring-performances/performance.ts
+++ b/custom-testing/measuring-performances/performance.ts
@@ -1,6 +1,6 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as url from "url";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
 
 import { Audit, Rule } from "@siteimprove/alfa-act";
 import * as aria from "@siteimprove/alfa-aria";
@@ -8,9 +8,14 @@ import { Cascade } from "@siteimprove/alfa-cascade";
 import { Performance } from "@siteimprove/alfa-performance";
 import { Scraper } from "@siteimprove/alfa-scraper";
 
-import rules, { Flattened } from "@siteimprove/alfa-rules";
+import rules from "@siteimprove/alfa-rules";
+import type { Flattened } from "@siteimprove/alfa-rules";
 
 const { isMeasure } = Performance.Measure;
+
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // We'll record the rules' performance in a duration object with this shape:
 interface Durations {
@@ -96,7 +101,7 @@ Scraper.with(async (scraper) => {
 
     // The Performance object with its callback listener is passed to the Audit
     // evaluation.
-    await Audit.of(page, rules).evaluate(rulesPerformance);
+    await Audit.of(page, rules.default).evaluate(rulesPerformance);
 
     // Closing the total duration measurement.
     commonPerformance.measure("total", start);

--- a/custom-testing/navigating/package.json
+++ b/custom-testing/navigating/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-chai": "^0.65.2",
     "@siteimprove/alfa-future": "^0.81.0",

--- a/custom-testing/navigating/test/navigating.spec.ts
+++ b/custom-testing/navigating/test/navigating.spec.ts
@@ -5,6 +5,8 @@ import { Future } from "@siteimprove/alfa-future";
 import { Playwright } from "@siteimprove/alfa-playwright";
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as playwright from "playwright";
 
 import * as alfa from "@siteimprove/alfa-chai";
@@ -24,6 +26,10 @@ chai.use(
 
 const { expect } = chai;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 describe("Navigating between pages", () => {
   let browser: playwright.Browser;
   let page: playwright.Page;
@@ -33,7 +39,9 @@ describe("Navigating between pages", () => {
     browser = await playwright.chromium.launch();
     page = await browser.newPage();
 
-    await page.goto(`file://${require.resolve("./fixtures/page1.html")}`);
+    await page.goto(
+      url.pathToFileURL(path.join(__dirname, "fixtures", "page1.html")).href
+    );
 
     document = await page.evaluateHandle(() => window.document);
   });

--- a/custom-testing/scraping/package.json
+++ b/custom-testing/scraping/package.json
@@ -2,6 +2,10 @@
   "$schema": "http://json.schemastore.org/package",
   "private": true,
   "name": "custom-testing-scraping",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "test": "node scraping.js"
   },

--- a/custom-testing/scraping/scraping.ts
+++ b/custom-testing/scraping/scraping.ts
@@ -1,12 +1,16 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as url from "url";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
 
 import { Audit, Outcome, Question } from "@siteimprove/alfa-act";
 import { Hashable } from "@siteimprove/alfa-hash";
 import { Scraper } from "@siteimprove/alfa-scraper";
 
 import rules from "@siteimprove/alfa-rules";
+
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const input = path.join(__dirname, "fixtures", "page.html");
 const output = path.join(__dirname, "outcomes", "page.html.json");
@@ -16,7 +20,7 @@ const page = process.argv?.[2] ?? local;
 
 Scraper.with(async (scraper) => {
   for (const input of await scraper.scrape(page)) {
-    const outcomes = await Audit.of(input, rules)
+    const outcomes = await Audit.of(input, rules.default)
       .evaluate()
       .map((outcomes) => [...outcomes]);
 
@@ -44,7 +48,9 @@ Scraper.with(async (scraper) => {
   }
 });
 
-function logStats<I, T extends Hashable, Q extends Question.Metadata>(outcomes: Array<Outcome<I, T, Q>>): void {
+function logStats<I, T extends Hashable, Q extends Question.Metadata>(
+  outcomes: Array<Outcome<I, T, Q>>
+): void {
   console.log(outcomes.filter(Outcome.isPassed).length, "passed outcomes");
 
   console.log(outcomes.filter(Outcome.isFailed).length, "failed outcomes");

--- a/custom-testing/scraping/scraping.ts
+++ b/custom-testing/scraping/scraping.ts
@@ -19,7 +19,16 @@ const local = url.pathToFileURL(input).toString();
 const page = process.argv?.[2] ?? local;
 
 Scraper.with(async (scraper) => {
-  for (const input of await scraper.scrape(page)) {
+  const alfaPage = await scraper.scrape(page);
+
+  if (alfaPage.isErr()) {
+    // If the scrape failed, exit with non-0 code.
+    console.error(alfaPage.getErr());
+
+    process.exit(1);
+  }
+
+  for (const input of alfaPage) {
     const outcomes = await Audit.of(input, rules.default)
       .evaluate()
       .map((outcomes) => [...outcomes]);

--- a/end-to-end-testing/README.md
+++ b/end-to-end-testing/README.md
@@ -11,6 +11,4 @@ The tests are run on a full page, and all rules are applied.
 
 Note that the Cypress tests are currently not running due to conflict with the build target, Cypress does not support the latest versions of ES.
 
-Note that the Puppeteer tests are currently not running due to some problem in the Ubuntu runner with Mocha syntax (seems to be fine in Powershell).
-
 Note that the Webdriver test are currently not running due to some security settings on chromedriver which doesn't consider the page as a local connection.

--- a/end-to-end-testing/README.md
+++ b/end-to-end-testing/README.md
@@ -11,4 +11,6 @@ The tests are run on a full page, and all rules are applied.
 
 Note that the Cypress tests are currently not running due to conflict with the build target, Cypress does not support the latest versions of ES.
 
+Note that the Puppeteer tests are currently not running due to some problem in the Ubuntu runner with Mocha syntax (seems to be fine in Powershell).
+
 Note that the Webdriver test are currently not running due to some security settings on chromedriver which doesn't consider the page as a local connection.

--- a/end-to-end-testing/cypress/package.json
+++ b/end-to-end-testing/cypress/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "cypress run"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-cypress": "^0.65.2",
     "@siteimprove/alfa-rules": "^0.81.0",

--- a/end-to-end-testing/cypress/support.ts
+++ b/end-to-end-testing/cypress/support.ts
@@ -3,7 +3,7 @@ import { Cypress } from "@siteimprove/alfa-cypress";
 import rules from "@siteimprove/alfa-rules";
 
 chai.use(
-  Cypress.createPlugin(rules, [
+  Cypress.createPlugin(rules.default, [
     Cypress.Handler.persist(() => "outcomes/page.spec.json"),
   ])
 );

--- a/end-to-end-testing/playwright/package.json
+++ b/end-to-end-testing/playwright/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha --timeout 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-chai": "^0.65.2",
     "@siteimprove/alfa-future": "^0.81.0",

--- a/end-to-end-testing/playwright/test/page.spec.ts
+++ b/end-to-end-testing/playwright/test/page.spec.ts
@@ -1,6 +1,9 @@
 /// <reference types="node" />
 /// <reference types="mocha" />
 
+import * as path from "node:path";
+import * as url from "node:url";
+
 import * as chai from "chai";
 import * as playwright from "playwright";
 
@@ -12,10 +15,14 @@ import rules from "@siteimprove/alfa-rules";
 
 import { persist } from "common/persist";
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 chai.use(
   alfa.Chai.createPlugin(
     (value: Playwright.Type) => Future.from(Playwright.toPage(value)),
-    rules.filter((rule) => !rule.uri.includes("r111")),
+    rules.default.filter((rule) => !rule.uri.includes("r111")),
     [persist(() => "test/outcomes/page.spec.json")]
   )
 );
@@ -31,7 +38,11 @@ describe("page.html", () => {
     browser = await playwright.chromium.launch();
     page = await browser.newPage();
 
-    await page.goto(`file://${require.resolve("../../fixtures/page.html")}`);
+    await page.goto(
+      url.pathToFileURL(
+        path.join(__dirname, "..", "..", "fixtures", "page.html")
+      ).href
+    );
 
     document = await page.evaluateHandle(() => window.document);
   });

--- a/end-to-end-testing/puppeteer/package.json
+++ b/end-to-end-testing/puppeteer/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "mocha -t 10000"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-chai": "^0.65.2",
     "@siteimprove/alfa-future": "^0.81.0",

--- a/end-to-end-testing/puppeteer/test/page.spec.ts
+++ b/end-to-end-testing/puppeteer/test/page.spec.ts
@@ -49,7 +49,7 @@ describe("page.html", () => {
     await browser.close();
   });
 
-  it("should be accessible", (done) => {
-    expect(document).to.be.accessible().then(done, done);
+  it("should be accessible", async () => {
+    await expect(document).to.be.accessible();
   });
 });

--- a/end-to-end-testing/puppeteer/test/page.spec.ts
+++ b/end-to-end-testing/puppeteer/test/page.spec.ts
@@ -49,7 +49,7 @@ describe("page.html", () => {
     await browser.close();
   });
 
-  it("should be accessible", async () => {
-    await expect(document).to.be.accessible();
+  it("should be accessible", (done) => {
+    expect(document).to.be.accessible().then(done, done);
   });
 });

--- a/end-to-end-testing/puppeteer/test/page.spec.ts
+++ b/end-to-end-testing/puppeteer/test/page.spec.ts
@@ -1,6 +1,8 @@
 /// <reference types="mocha" />
 
 import * as chai from "chai";
+import * as path from "node:path";
+import * as url from "node:url";
 import * as puppeteer from "puppeteer";
 
 import { Future } from "@siteimprove/alfa-future";
@@ -14,12 +16,16 @@ import { persist } from "common/persist";
 chai.use(
   alfa.Chai.createPlugin(
     (value: Puppeteer.Type) => Future.from(Puppeteer.toPage(value)),
-    rules,
+    rules.default,
     [persist(() => "test/outcomes/page.spec.json")]
   )
 );
 
 const { expect } = chai;
+
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 describe("page.html", () => {
   let browser: puppeteer.Browser;
@@ -30,7 +36,11 @@ describe("page.html", () => {
     browser = await puppeteer.launch();
     page = await browser.newPage();
 
-    await page.goto(`file://${require.resolve("../../fixtures/page.html")}`);
+    await page.goto(
+      url.pathToFileURL(
+        path.join(__dirname, "..", "..", "fixtures", "page.html")
+      ).href
+    );
 
     document = await page.evaluateHandle(() => window.document);
   });

--- a/end-to-end-testing/puppeteer/test/page.spec.ts
+++ b/end-to-end-testing/puppeteer/test/page.spec.ts
@@ -16,7 +16,7 @@ import { persist } from "common/persist";
 chai.use(
   alfa.Chai.createPlugin(
     (value: Puppeteer.Type) => Future.from(Puppeteer.toPage(value)),
-    rules.default,
+    rules.default.filter((rule) => !rule.uri.includes("r111")),
     [persist(() => "test/outcomes/page.spec.json")]
   )
 );
@@ -33,7 +33,7 @@ describe("page.html", () => {
   let document: puppeteer.JSHandle;
 
   before(async () => {
-    browser = await puppeteer.launch();
+    browser = await puppeteer.default.launch();
     page = await browser.newPage();
 
     await page.goto(

--- a/end-to-end-testing/webdriver/package.json
+++ b/end-to-end-testing/webdriver/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "wdio wdio.conf.js"
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-chai": "^0.65.2",
     "@siteimprove/alfa-future": "^0.81.0",

--- a/end-to-end-testing/webdriver/test/page.spec.ts
+++ b/end-to-end-testing/webdriver/test/page.spec.ts
@@ -7,20 +7,28 @@ import * as alfa from "@siteimprove/alfa-chai";
 import rules from "@siteimprove/alfa-rules";
 
 import { persist } from "common/persist";
+import * as path from "node:path";
+import * as url from "node:url";
 
 chai.use(
   alfa.Chai.createPlugin(
     (value: WebElement) => Future.from(WebElement.toPage(value, browser)),
-    rules,
+    rules.default,
     [persist(() => "test/outcomes/page.spec.json")]
   )
 );
 
 const { expect } = chai;
 
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 describe("page.html", () => {
   before(async () => {
-    await browser.url(`file://${require.resolve("./fixtures/page.html")}`);
+    await browser.url(
+      url.pathToFileURL(path.join(__dirname, "fixtures", "page.html")).href
+    );
   });
 
   it("should be accessible", async () => {

--- a/end-to-end-testing/webdriver/wdio.conf.ts
+++ b/end-to-end-testing/webdriver/wdio.conf.ts
@@ -1,3 +1,10 @@
+// TODO: This should be replaced with import.meta.dirname once we switch to Node 22
+import * as path from "node:path";
+import * as url from "node:url";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export const config: WebdriverIO.Config = {
   runner: "local",
   path: "/",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --build --watch",
     "clean": "tsc --build --clean",
     "knip": "knip -c config/knip.ts",
-    "test": "yarn workspaces foreach -v -p --exclude 'end-to-end-testing-{cypress,puppeteer,webdriver}' --exclude 'custom-testing-{crawling,scraping,measuring-performance}' --exclude 'unit-testing-angular' run test"
+    "test": "yarn workspaces foreach -v -p --exclude 'end-to-end-testing-{cypress,webdriver}' --exclude 'custom-testing-{crawling,scraping,measuring-performance}' --exclude 'unit-testing-angular' run test"
   },
   "workspaces": [
     "common",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc --build --watch",
     "clean": "tsc --build --clean",
     "knip": "knip -c config/knip.ts",
-    "test": "yarn workspaces foreach -v -p --exclude 'end-to-end-testing-{cypress,webdriver}' --exclude 'custom-testing-{crawling,scraping,measuring-performance}' --exclude 'unit-testing-angular' run test"
+    "test": "yarn workspaces foreach -v -p --exclude 'end-to-end-testing-{cypress,puppeteer,webdriver}' --exclude 'custom-testing-{crawling,measuring-performance}' --exclude 'unit-testing-angular' run test"
   },
   "workspaces": [
     "common",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,13 @@
     "declaration": true,
     "declarationMap": true,
     "incremental": true,
-    "lib": ["es2020", "dom"],
-    "module": "commonjs",
+    "lib": ["es2022", "dom"],
+    "module": "Node16",
     "sourceMap": true,
     "strict": true,
-    "target": "es2020",
-    "types": ["node"]
+    "target": "es2022",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
   },
   "files": [],
   "references": [

--- a/unit-testing/angular/components/button.spec.ts
+++ b/unit-testing/angular/components/button.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="@siteimprove/alfa-jest" />
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { EmptyButtonComponent, NamedButtonComponent } from "./button";
+import { EmptyButtonComponent, NamedButtonComponent } from "./button.js";
 
 let emptyFixture: ComponentFixture<EmptyButtonComponent>;
 let namedFixture: ComponentFixture<NamedButtonComponent>;

--- a/unit-testing/angular/package.json
+++ b/unit-testing/angular/package.json
@@ -28,6 +28,10 @@
     },
     "verbose": true
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@angular/core": "^11.0.5",
     "@angular/platform-browser-dynamic": "^8.2.0",

--- a/unit-testing/react/components/button.spec.tsx
+++ b/unit-testing/react/components/button.spec.tsx
@@ -1,13 +1,13 @@
 /// <reference types="@siteimprove/alfa-jest" />
 
-import { shallow } from "enzyme";
+import * as enzyme from "enzyme";
 
-import { Button } from "./button";
+import { Button } from "./button.js";
 
 it("should not have a name", async () => {
-  await expect(shallow(<Button></Button>)).not.toBeAccessible();
+  await expect(enzyme.default.shallow(<Button></Button>)).not.toBeAccessible();
 });
 
 it("should have a name", async () => {
-  await expect(shallow(<Button>Hello</Button>)).toBeAccessible();
+  await expect(enzyme.default.shallow(<Button>Hello</Button>)).toBeAccessible();
 });

--- a/unit-testing/react/components/button.tsx
+++ b/unit-testing/react/components/button.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react";
+import type { FunctionComponent } from "react";
 
 export const Button: FunctionComponent = ({ children }) => (
   <button className="btn">{children}</button>

--- a/unit-testing/react/package.json
+++ b/unit-testing/react/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "name": "unit-testing-react",
   "scripts": {
-    "test": "jest"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "jest": {
     "setupFilesAfterEnv": [
@@ -12,6 +12,7 @@
     "transformIgnorePatterns": [
       "^.+\\.js$"
     ],
+    "transform": {},
     "moduleFileExtensions": [
       "js"
     ]

--- a/unit-testing/react/package.json
+++ b/unit-testing/react/package.json
@@ -16,6 +16,10 @@
       "js"
     ]
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "devDependencies": {
     "@siteimprove/alfa-enzyme": "^0.65.2",
     "@siteimprove/alfa-jest": "^0.65.2",

--- a/unit-testing/react/setup.ts
+++ b/unit-testing/react/setup.ts
@@ -11,7 +11,7 @@ import Adapter from "enzyme-adapter-react-16";
 
 import { persist } from "common/persist";
 
-enzyme.configure({ adapter: new Adapter() });
+enzyme.default.configure({ adapter: new Adapter() });
 
 alfa.Jest.createPlugin(
   (value: Enzyme.Type) => Enzyme.toPage(value),

--- a/unit-testing/vue/components/button.spec.ts
+++ b/unit-testing/vue/components/button.spec.ts
@@ -2,7 +2,7 @@
 
 import { mount } from "@vue/test-utils";
 
-import { EmptyButton, NamedButton } from "./button";
+import { EmptyButton, NamedButton } from "./button.js";
 
 // window.matchMedia is not currently implemented by JSDOM, used by Jest, so
 // we need to mock it.

--- a/unit-testing/vue/components/button.ts
+++ b/unit-testing/vue/components/button.ts
@@ -2,13 +2,21 @@
 
 import Vue from "vue";
 
-export const EmptyButton = Vue.default.extend({
+/**
+ * For some reason, TS struggle with Vue and believe it should be used
+ * with a "double default" (`Vue.default.extend`), but JS is perfectly fine
+ * with the (correct) `Vue.extend`.
+ */
+
+// @ts-ignore
+export const EmptyButton = Vue.extend({
   template: `
     <button class="btn"></button>
   `,
 });
 
-export const NamedButton = Vue.default.extend({
+// @ts-ignore
+export const NamedButton = Vue.extend({
   template: `
     <button class="btn">Hello</button>
   `,

--- a/unit-testing/vue/components/button.ts
+++ b/unit-testing/vue/components/button.ts
@@ -2,13 +2,13 @@
 
 import Vue from "vue";
 
-export const EmptyButton = Vue.extend({
+export const EmptyButton = Vue.default.extend({
   template: `
     <button class="btn"></button>
   `,
 });
 
-export const NamedButton = Vue.extend({
+export const NamedButton = Vue.default.extend({
   template: `
     <button class="btn">Hello</button>
   `,

--- a/unit-testing/vue/jsdom-environment.ts
+++ b/unit-testing/vue/jsdom-environment.ts
@@ -1,0 +1,21 @@
+/**
+ * {@link https://github.com/mswjs/mswjs.io/issues/292#issue-1977585807}
+ */
+
+import type {
+  EnvironmentContext,
+  JestEnvironmentConfig,
+} from "@jest/environment";
+
+import JSDOMEnvironment from "jest-environment-jsdom";
+
+export class MyJSDOMEnvironment extends JSDOMEnvironment.default {
+  constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    super(config, context);
+
+    // here, you have access to regular Node globals, which you can add to the test environment
+    this.global.TextEncoder = TextEncoder;
+  }
+}
+
+export default MyJSDOMEnvironment;

--- a/unit-testing/vue/jsdom-environment.ts
+++ b/unit-testing/vue/jsdom-environment.ts
@@ -1,4 +1,6 @@
 /**
+ * Workaround for the missing `TextEncoder` in JSDOM.
+ *
  * {@link https://github.com/mswjs/mswjs.io/issues/292#issue-1977585807}
  */
 

--- a/unit-testing/vue/jsdom-environment.ts
+++ b/unit-testing/vue/jsdom-environment.ts
@@ -11,7 +11,7 @@ import type {
 
 import JSDOMEnvironment from "jest-environment-jsdom";
 
-export class MyJSDOMEnvironment extends JSDOMEnvironment.default {
+class MyJSDOMEnvironment extends JSDOMEnvironment.default {
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     super(config, context);
 

--- a/unit-testing/vue/package.json
+++ b/unit-testing/vue/package.json
@@ -31,6 +31,7 @@
     "vue-template-compiler": "^2.6.12"
   },
   "devDependencies": {
+    "@jest/environment": "^29.7.0",
     "@siteimprove/alfa-future": "^0.81.0",
     "@siteimprove/alfa-jest": "^0.65.2",
     "@siteimprove/alfa-rules": "^0.81.0",

--- a/unit-testing/vue/package.json
+++ b/unit-testing/vue/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "name": "unit-testing-vue",
   "scripts": {
-    "test": "jest"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "jest": {
     "setupFilesAfterEnv": [
@@ -12,10 +12,11 @@
     "transformIgnorePatterns": [
       "^.+\\.js$"
     ],
+    "transform": {},
     "moduleFileExtensions": [
       "js"
     ],
-    "testEnvironment": "jsdom",
+    "testEnvironment": "./jsdom-environment.js",
     "testEnvironmentOptions": {
       "url": "http://localhost/"
     },

--- a/unit-testing/vue/package.json
+++ b/unit-testing/vue/package.json
@@ -21,6 +21,10 @@
     },
     "verbose": true
   },
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "vue": "^2.6.12",
     "vue-template-compiler": "^2.6.12"

--- a/unit-testing/vue/setup.ts
+++ b/unit-testing/vue/setup.ts
@@ -7,8 +7,8 @@ import * as alfa from "@siteimprove/alfa-jest";
 // It might be something that needs to be fixed in alfa-jest, but we seem to not
 // be the only ones with this problem.
 // See https://github.com/inrupt/solid-client-authn-js/issues/1676#issuecomment-917016646
-import { TextEncoder } from "util";
-global.TextEncoder = TextEncoder;
+import { TextEncoder } from "node:util";
+globalThis.TextEncoder = globalThis.TextEncoder || TextEncoder;
 
 // Only selecting a rule that apply to buttons.
 import { Rules } from "@siteimprove/alfa-rules";

--- a/unit-testing/vue/setup.ts
+++ b/unit-testing/vue/setup.ts
@@ -3,13 +3,6 @@ import { Vue } from "@siteimprove/alfa-vue";
 
 import * as alfa from "@siteimprove/alfa-jest";
 
-// Not sure why this is needed, but it fixes a missing TextEncoder problem.
-// It might be something that needs to be fixed in alfa-jest, but we seem to not
-// be the only ones with this problem.
-// See https://github.com/inrupt/solid-client-authn-js/issues/1676#issuecomment-917016646
-import { TextEncoder } from "node:util";
-globalThis.TextEncoder = globalThis.TextEncoder || TextEncoder;
-
 // Only selecting a rule that apply to buttons.
 import { Rules } from "@siteimprove/alfa-rules";
 const R12 = Rules.get("R12").getUnsafe();

--- a/unit-testing/vue/tsconfig.json
+++ b/unit-testing/vue/tsconfig.json
@@ -3,12 +3,14 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": true,
-    "types": ["jest"]
+    "types": ["jest"],
+    "skipLibCheck": true
   },
-  "files": ["components/button.spec.ts", "components/button.ts", "setup.ts"],
-  "references": [
-    {
-      "path": "../../common"
-    }
-  ]
+  "files": [
+    "components/button.spec.ts",
+    "components/button.ts",
+    "jsdom-environment.ts",
+    "setup.ts"
+  ],
+  "references": [{ "path": "../../common" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,19 +757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/environment@npm:29.5.0"
-  dependencies:
-    "@jest/fake-timers": ^29.5.0
-    "@jest/types": ^29.5.0
-    "@types/node": "*"
-    jest-mock: ^29.5.0
-  checksum: 921de6325cd4817dec6685e5ff299b499b6379f3f9cf489b4b13588ee1f3820a0c77b49e6a087996b6de8f629f6f5251e636cba08d1bdb97d8071cc7d033c88a
-  languageName: node
-  linkType: hard
-
-"@jest/environment@npm:^29.7.0":
+"@jest/environment@npm:^29.5.0, @jest/environment@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/environment@npm:29.7.0"
   dependencies:
@@ -800,21 +788,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/fake-timers@npm:29.5.0"
-  dependencies:
-    "@jest/types": ^29.5.0
-    "@sinonjs/fake-timers": ^10.0.2
-    "@types/node": "*"
-    jest-message-util: ^29.5.0
-    jest-mock: ^29.5.0
-    jest-util: ^29.5.0
-  checksum: 69930c6922341f244151ec0d27640852ec96237f730fc024da1f53143d31b43cde75d92f9d8e5937981cdce3b31416abc3a7090a0d22c2377512c4a6613244ee
-  languageName: node
-  linkType: hard
-
-"@jest/fake-timers@npm:^29.7.0":
+"@jest/fake-timers@npm:^29.5.0, @jest/fake-timers@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/fake-timers@npm:29.7.0"
   dependencies:
@@ -874,15 +848,6 @@ __metadata:
     node-notifier:
       optional: true
   checksum: 481268aac9a4a75cc49c4df1273d6b111808dec815e9d009dad717c32383ebb0cebac76e820ad1ab44e207540e1c2fe1e640d44c4f262de92ab1933e057fdeeb
-  languageName: node
-  linkType: hard
-
-"@jest/schemas@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "@jest/schemas@npm:29.4.3"
-  dependencies:
-    "@sinclair/typebox": ^0.25.16
-  checksum: ac754e245c19dc39e10ebd41dce09040214c96a4cd8efa143b82148e383e45128f24599195ab4f01433adae4ccfbe2db6574c90db2862ccd8551a86704b5bebd
   languageName: node
   linkType: hard
 
@@ -966,21 +931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/types@npm:29.5.0"
-  dependencies:
-    "@jest/schemas": ^29.4.3
-    "@types/istanbul-lib-coverage": ^2.0.0
-    "@types/istanbul-reports": ^3.0.0
-    "@types/node": "*"
-    "@types/yargs": ^17.0.8
-    chalk: ^4.0.0
-  checksum: 1811f94b19cf8a9460a289c4f056796cfc373480e0492692a6125a553cd1a63824bd846d7bb78820b7b6f758f6dd3c2d4558293bb676d541b2fa59c70fdf9d39
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:^29.6.3":
+"@jest/types@npm:^29.5.0, @jest/types@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/types@npm:29.6.3"
   dependencies:
@@ -1100,13 +1051,6 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: d75fde03be4be106ca907834739251c2bb0b33a09fa23315c5dbe8b8b4cfed2f1b26af62e1dbe5fccc227e9bc87b51da0815461b982477eb01439bfdd6e7b01a
-  languageName: node
-  linkType: hard
-
-"@sinclair/typebox@npm:^0.25.16":
-  version: 0.25.24
-  resolution: "@sinclair/typebox@npm:0.25.24"
-  checksum: 10219c58f40b8414c50b483b0550445e9710d4fe7b2c4dccb9b66533dd90ba8e024acc776026cebe81e87f06fa24b07fdd7bc30dd277eb9cc386ec50151a3026
   languageName: node
   linkType: hard
 
@@ -7569,24 +7513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-message-util@npm:29.5.0"
-  dependencies:
-    "@babel/code-frame": ^7.12.13
-    "@jest/types": ^29.5.0
-    "@types/stack-utils": ^2.0.0
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    micromatch: ^4.0.4
-    pretty-format: ^29.5.0
-    slash: ^3.0.0
-    stack-utils: ^2.0.3
-  checksum: daddece6bbf846eb6a2ab9be9f2446e54085bef4e5cecd13d2a538fa9c01cb89d38e564c6b74fd8e12d37ed9eface8a362240ae9f21d68b214590631e7a0d8bf
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:^29.7.0":
+"jest-message-util@npm:^29.5.0, jest-message-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-message-util@npm:29.7.0"
   dependencies:
@@ -7603,18 +7530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-mock@npm:29.5.0"
-  dependencies:
-    "@jest/types": ^29.5.0
-    "@types/node": "*"
-    jest-util: ^29.5.0
-  checksum: 2a9cf07509948fa8608898c445f04fe4dd6e2049ff431e5531eee028c808d3ba3c67f226ac87b0cf383feaa1055776900d197c895e89783016886ac17a4ff10c
-  languageName: node
-  linkType: hard
-
-"jest-mock@npm:^29.7.0":
+"jest-mock@npm:^29.5.0, jest-mock@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-mock@npm:29.7.0"
   dependencies:
@@ -7793,21 +7709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-util@npm:29.5.0"
-  dependencies:
-    "@jest/types": ^29.5.0
-    "@types/node": "*"
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  checksum: fd9212950d34d2ecad8c990dda0d8ea59a8a554b0c188b53ea5d6c4a0829a64f2e1d49e6e85e812014933d17426d7136da4785f9cf76fff1799de51b88bc85d3
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^29.7.0":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.5.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -9502,18 +9404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "pretty-format@npm:29.5.0"
-  dependencies:
-    "@jest/schemas": ^29.4.3
-    ansi-styles: ^5.0.0
-    react-is: ^18.0.0
-  checksum: 4065356b558e6db25b4d41a01efb386935a6c06a0c9c104ef5ce59f2f476b8210edb8b3949b386e60ada0a6dc5ebcb2e6ccddc8c64dfd1a9943c3c3a9e7eaf89
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.5.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/environment@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/environment@npm:29.7.0"
+  dependencies:
+    "@jest/fake-timers": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    jest-mock: ^29.7.0
+  checksum: 6fb398143b2543d4b9b8d1c6dbce83fa5247f84f550330604be744e24c2bd2178bb893657d62d1b97cf2f24baf85c450223f8237cccb71192c36a38ea2272934
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^29.5.0":
   version: 29.5.0
   resolution: "@jest/expect-utils@npm:29.5.0"
@@ -799,6 +811,20 @@ __metadata:
     jest-mock: ^29.5.0
     jest-util: ^29.5.0
   checksum: 69930c6922341f244151ec0d27640852ec96237f730fc024da1f53143d31b43cde75d92f9d8e5937981cdce3b31416abc3a7090a0d22c2377512c4a6613244ee
+  languageName: node
+  linkType: hard
+
+"@jest/fake-timers@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/fake-timers@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    "@sinonjs/fake-timers": ^10.0.2
+    "@types/node": "*"
+    jest-message-util: ^29.7.0
+    jest-mock: ^29.7.0
+    jest-util: ^29.7.0
+  checksum: caf2bbd11f71c9241b458d1b5a66cbe95debc5a15d96442444b5d5c7ba774f523c76627c6931cca5e10e76f0d08761f6f1f01a608898f4751a0eee54fc3d8d00
   languageName: node
   linkType: hard
 
@@ -857,6 +883,15 @@ __metadata:
   dependencies:
     "@sinclair/typebox": ^0.25.16
   checksum: ac754e245c19dc39e10ebd41dce09040214c96a4cd8efa143b82148e383e45128f24599195ab4f01433adae4ccfbe2db6574c90db2862ccd8551a86704b5bebd
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
+  dependencies:
+    "@sinclair/typebox": ^0.27.8
+  checksum: 910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
   languageName: node
   linkType: hard
 
@@ -942,6 +977,20 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: 1811f94b19cf8a9460a289c4f056796cfc373480e0492692a6125a553cd1a63824bd846d7bb78820b7b6f758f6dd3c2d4558293bb676d541b2fa59c70fdf9d39
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/types@npm:29.6.3"
+  dependencies:
+    "@jest/schemas": ^29.6.3
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: a0bcf15dbb0eca6bdd8ce61a3fb055349d40268622a7670a3b2eb3c3dbafe9eb26af59938366d520b86907b9505b0f9b29b85cec11579a9e580694b87cd90fcc
   languageName: node
   linkType: hard
 
@@ -1058,6 +1107,13 @@ __metadata:
   version: 0.25.24
   resolution: "@sinclair/typebox@npm:0.25.24"
   checksum: 10219c58f40b8414c50b483b0550445e9710d4fe7b2c4dccb9b66533dd90ba8e024acc776026cebe81e87f06fa24b07fdd7bc30dd277eb9cc386ec50151a3026
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 00bd7362a3439021aa1ea51b0e0d0a0e8ca1351a3d54c606b115fdcc49b51b16db6e5f43b4fe7a28c38688523e22a94d49dd31168868b655f0d4d50f032d07a1
   languageName: node
   linkType: hard
 
@@ -7530,6 +7586,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-message-util@npm:29.7.0"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.6.3
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.7.0
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: a9d025b1c6726a2ff17d54cc694de088b0489456c69106be6b615db7a51b7beb66788bea7a59991a019d924fbf20f67d085a445aedb9a4d6760363f4d7d09930
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^29.5.0":
   version: 29.5.0
   resolution: "jest-mock@npm:29.5.0"
@@ -7538,6 +7611,17 @@ __metadata:
     "@types/node": "*"
     jest-util: ^29.5.0
   checksum: 2a9cf07509948fa8608898c445f04fe4dd6e2049ff431e5531eee028c808d3ba3c67f226ac87b0cf383feaa1055776900d197c895e89783016886ac17a4ff10c
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-mock@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    jest-util: ^29.7.0
+  checksum: 81ba9b68689a60be1482212878973700347cb72833c5e5af09895882b9eb5c4e02843a1bbdf23f94c52d42708bab53a30c45a3482952c9eec173d1eaac5b86c5
   languageName: node
   linkType: hard
 
@@ -7720,6 +7804,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: fd9212950d34d2ecad8c990dda0d8ea59a8a554b0c188b53ea5d6c4a0829a64f2e1d49e6e85e812014933d17426d7136da4785f9cf76fff1799de51b88bc85d3
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: 042ab4980f4ccd4d50226e01e5c7376a8556b472442ca6091a8f102488c0f22e6e8b89ea874111d2328a2080083bf3225c86f3788c52af0bd0345a00eb57a3ca
   languageName: node
   linkType: hard
 
@@ -9412,6 +9510,17 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
   checksum: 4065356b558e6db25b4d41a01efb386935a6c06a0c9c104ef5ce59f2f476b8210edb8b3949b386e60ada0a6dc5ebcb2e6ccddc8c64dfd1a9943c3c3a9e7eaf89
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
+  dependencies:
+    "@jest/schemas": ^29.6.3
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 032c1602383e71e9c0c02a01bbd25d6759d60e9c7cf21937dde8357aa753da348fcec5def5d1002c9678a8524d5fe099ad98861286550ef44de8808cc61e43b6
   languageName: node
   linkType: hard
 
@@ -11139,6 +11248,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "unit-testing-vue@workspace:unit-testing/vue"
   dependencies:
+    "@jest/environment": ^29.7.0
     "@siteimprove/alfa-future": ^0.81.0
     "@siteimprove/alfa-jest": ^0.65.2
     "@siteimprove/alfa-rules": ^0.81.0


### PR DESCRIPTION
Switch to ESM and update TS config.
Closes https://github.com/Siteimprove/alfa/issues/1621

There are still a bunch of "double `default`" hacks, which I hope bare due to this still using the CJS version of Alfa and might disappear once switching to the ESM version.