### PR TITLE
Improve Code Checker workflow

### DIFF
--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    schedule:
+      # Run weekly, on Monday morning at 05:00 UTC.
+      # Problems are reported to the latest editor of the script,
+      # currently https://github.com/Jym77
+      - cron: '0 5 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/code-checker.yml
+++ b/.github/workflows/code-checker.yml
@@ -5,6 +5,9 @@
 
 # See https://alfa.siteimprove.com/code-checker
 
+# Note that even if the code checker step by itself fails, the full workflow doesn't.
+# This reduces noise, and ensure that other problems in the workflow will still be reported.
+
 name: Accessibility Code Checker (this workflow *should* fail!)
 on:
   push:
@@ -19,7 +22,7 @@ on:
 
 jobs:
   build:
-    name: Accessibility Code Checker (this workflow *should* fail!)
+    name: Accessibility Code Checker
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,3 +49,6 @@ jobs:
         env:
           SI_USER_EMAIL: ${{ secrets.SI_USER_EMAIL }}
           SI_API_KEY: ${{ secrets.SI_API_KEY }}
+      - name: Expect failure of previous step
+        if: ${{ failure() }}
+        run: echo "Code Checker failed as expected"


### PR DESCRIPTION
* Run the code checker weekly. This ensure we will always have a saved run and Page Report for demo purpose.
* Do not fail the workflow when the code checker fail. Since this it the expected behaviour, we do not want it to be reported in order to decrease noise and to allow us to detect actual problems with the workflow should they arise.