### PR TITLE
Use global site ID

### DIFF
--- a/accessibility-code-checker/cypress/cypress.config.ts
+++ b/accessibility-code-checker/cypress/cypress.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
           const apiKey = process.env.SI_API_KEY;
 
           // (mandatory) Setup site ID; TODO: replace with your own.
-          const siteID = 900788;
+          const siteID = 16788956729;
 
           // (recommended) Fetch information about the latest commit
           const gitInformation = await getCommitInformation();

--- a/accessibility-code-checker/playwright/test/playwright.spec.ts
+++ b/accessibility-code-checker/playwright/test/playwright.spec.ts
@@ -34,7 +34,7 @@ test("is page accessible", async ({ page }) => {
   const apiKey = process.env.SI_API_KEY;
 
   // (mandatory) Setup site ID; TODO: replace with your own.
-  const siteID = 900788;
+  const siteID = 16788956729;
 
   // (recommended) Fetch information about the latest commit
   const gitInformation = await getCommitInformation();

--- a/accessibility-code-checker/puppeteer/test/puppeteer.spec.ts
+++ b/accessibility-code-checker/puppeteer/test/puppeteer.spec.ts
@@ -46,7 +46,7 @@ test("Page should be accessible", async (t) => {
   const apiKey = process.env.SI_API_KEY;
 
   // (mandatory) Setup site ID; TODO: replace with your own.
-  const siteID = 900788;
+  const siteID = 16788956729;
 
   // (recommended) Fetch information about the latest commit
   const gitInformation = await getCommitInformation();

--- a/accessibility-code-checker/selenium/test/selenium.spec.ts
+++ b/accessibility-code-checker/selenium/test/selenium.spec.ts
@@ -48,7 +48,7 @@ test("Page should be accessible", async (t) => {
   const apiKey = process.env.SI_API_KEY;
 
   // (mandatory) Setup site ID; TODO: replace with your own.
-  const siteID = 900788;
+  const siteID = 16788956729;
 
   // (recommended) Fetch information about the latest commit
   const gitInformation = await getCommitInformation();


### PR DESCRIPTION
Following change in the API, we now expect the global site ID.